### PR TITLE
Allow deepCopy to handle objects with cycles

### DIFF
--- a/sinful.js
+++ b/sinful.js
@@ -78,7 +78,8 @@ void function () {
 
 
     Object.prototype.deepCopy = function () {
-
+	var thingStack = [];
+	var copyStack = [];
 	function clone (thing) {
 
 	    if (thing ===  null           ||
@@ -94,9 +95,17 @@ void function () {
 	    }
 
 	    var copy = Array.isArray(thing) ? [] : {};
-
+	    thingStack.push(thing);
+	    copyStack.push(copy);
 	    Object.getOwnPropertyNames(thing).forEach(function (prop) {
-		copy[prop] = clone(thing[prop]);
+		var thingOffset = thingStack.indexOf(thing[prop]);
+		if(thingOffset === -1){
+		    copy[prop] = clone(thing[prop]);
+		    thingStack.push(thing[prop]);
+		    copyStack.push(copy[prop]);
+		}else{
+		    copy[prop] = copyStack[thingOffset];
+		}
 	    });
 
 	    return copy;


### PR DESCRIPTION
Previously, deepCopy would crash the browser or hit the max call stack due to infinite recursion if any object contained cycles. Added a simple mechanism to detect and correctly copy the correct previously-copied values to different properties.
