### PR TITLE
deepCopy now correctly copies the cloned objects' prototypes

### DIFF
--- a/sinful.js
+++ b/sinful.js
@@ -94,7 +94,7 @@ void function () {
 		return undefined;
 	    }
 
-	    var copy = Array.isArray(thing) ? [] : {};
+	    var copy = Array.isArray(thing) ? [] : Object.create(Object.getPrototypeOf(thing));
 	    thingStack.push(thing);
 	    copyStack.push(copy);
 	    Object.getOwnPropertyNames(thing).forEach(function (prop) {


### PR DESCRIPTION
Objects can have a prototype set. This change correctly copies the prototype as well to ensure the cloned objects behave identically to the original objects.
