### PR TITLE
Added an optional 'depth' argument to Function.prototype.curry

### DIFF
--- a/sinful.js
+++ b/sinful.js
@@ -135,25 +135,34 @@ void function () {
     };
 
 
+Function.prototype.curry = function (depth) { 
 
-    Function.prototype.curry = function (depth) {
+        if ( arguments.length > 1 ) {
+             throw new Error('Takes a single argument, ' + arguments.length + ' provided.');
+        }
 
-        var that = this,
-            args = slice.call(arguments, 1),
-            arity = depth == null ? this.length : depth;
-        
-        return function () {
+        var arity = depth == null ?  this.length : depth,
 
-            var allArgs = args.concat(slice.call(arguments));
+            curry = function (arity) {
 
-            return allArgs.length >= arity ? 
-                that.apply(this, allArgs) :
-                that.curry.apply(that, [arity].concat(allArgs));
+            var that = this,
+                args = slice.call(arguments, 1);
+            
+            return function () {
+
+                var allArgs = args.concat(slice.call(arguments));
+
+                return allArgs.length >= arity ? 
+                    that.apply(this, allArgs) :
+                    curry.apply(that, [arity].concat(allArgs));
+
+            };
 
         };
 
-    };
+        return curry.call(this, arity);
 
+    };
 
     Function.prototype.compose = function (other) {
 

--- a/sinful.js
+++ b/sinful.js
@@ -136,19 +136,19 @@ void function () {
 
 
 
-    Function.prototype.curry = function () {
+    Function.prototype.curry = function (depth) {
 
         var that = this,
-            arity = this.length,
-            args = slice.call(arguments);
+            args = slice.call(arguments, 1),
+            arity = depth == null ? this.length : depth;
         
         return function () {
 
-            var allArgs = args.concat(slice.call(arguments))
+            var allArgs = args.concat(slice.call(arguments));
 
             return allArgs.length >= arity ? 
                 that.apply(this, allArgs) :
-                that.curry.apply(that, allArgs);
+                that.curry.apply(that, [arity].concat(allArgs));
 
         };
 

--- a/test/functionTest.js
+++ b/test/functionTest.js
@@ -31,5 +31,12 @@ test('Function.prototype.curry with a depth arg', function(){
         sum5 = sum.curry(5);
 
         a.equal(sum5(1, 2)(3, 4)(5), 15);
+})
+
+test('Function.prototype.curry with too many args', function(){
+
+    var f = function(){};
+
+    a.throws(function(){ f.curry(1, 2, 3) });
 
 })

--- a/test/functionTest.js
+++ b/test/functionTest.js
@@ -4,17 +4,32 @@ var a = require('assert');
 
 require('../sinful');
 
-test('Function.prototype.curry', function(){
+test('Function.prototype.curry with no args', function(){
 
-    var add = function(a, b){ return a + b }.curry()
+    var add = function (a, b) { return a + b }.curry();
 
     a.equal(add(1, 2), 3);
     a.equal(add()()()(1)(2), 3);
 
-    var add1= add(1)
-      , add2= add(2);
+    var add1= add(1),
+        add2= add(2);
 
     a.equal(add1(1), 2);
     a.equal(add2(1), 3);
 
 });
+
+test('Function.prototype.curry with a depth arg', function(){
+
+    var sum = function () {
+        
+            var nums = [].slice.call(arguments);
+            
+            return nums.reduce(function (a, b) { return a + b }, 0);
+
+        },
+        sum5 = sum.curry(5);
+
+        a.equal(sum5(1, 2)(3, 4)(5), 15);
+
+})


### PR DESCRIPTION
To close gh-6, I've added the depth parameter described therein to
Function.prototype.curry.

The complete signature now is:

```
curry([depth, [listOfInitialArgs..]])
```
