### PR TITLE
Moved 'use strict'; for greater robustness to build processes

### DIFF
--- a/sinful.js
+++ b/sinful.js
@@ -6,9 +6,10 @@
 // gdjs
 ///////
 
-'use strict';
 
 void function () {
+
+    'use strict';
 
     var own      = Object.getOwnPropertyNames,
         bind     = Function.prototype.bind,


### PR DESCRIPTION
As it stood, all files `cat`ed together with sinful.js would also
be bound by the 'use strict' restrictions.
