### PR TITLE
Cleaned up the implementation of liberate

### DIFF
--- a/sinful.js
+++ b/sinful.js
@@ -13,7 +13,7 @@ void function () {
 
     var own      = Object.getOwnPropertyNames,
         bind     = Function.prototype.bind,
-        liberate = bind.call(bind, Function.prototype.call),
+        liberate = bind.bind(Function.prototype.call),
         reduce   = liberate(Array.prototype.reduce),
         slice    = liberate(Array.prototype.slice);
 


### PR DESCRIPTION
It's far easier to understand this way; `bind.call(bind)` being just equivilent to `bind.bind` anyhow.
