### PR TITLE
add Array.sorter utility (sub-sort by multiple nested fields)

### DIFF
--- a/sinful.js
+++ b/sinful.js
@@ -360,6 +360,39 @@ void function (bless) {
 
 
 
+        // Array multi - sorter utility
+        // returns a sorter that can (sub-)sort by multiple (nested) fields 
+        // each ascending or descending independantly
+        // https://github.com/foo123/sinful.js
+        [Array, 'sorter', function () {
+
+            var arr = this, i, args = arguments, l = args.length,
+                a, b, step, lt, gt,
+                field, desc, sorter;
+            if ( l )
+            {
+                step = 1;
+                sorter = [];
+                for (i=l-1; i>=0; i--)
+                {
+                    field = args[i][0];
+                    field = '["' + field.split('.').join('"]["') + '"]';
+                    a = "a"+field; b = "b"+field;
+                    desc = args[i].length > 1 ? 0 > args[i][1] : false;
+                    lt = desc ? ''+step : '-'+step; gt = desc ? '-'+step : ''+step;
+                    sorter.unshift("("+a+" < "+b+" ? "+lt+" : ("+a+" > "+b+" ? "+gt+" : 0))");
+                    step <<= 1;
+                }
+                sorter = sorter.join(' + ');
+            }
+            else
+            {
+                a = "a"; b = "b"; lt = '-1'; gt = '1';
+                sorter = ""+a+" < "+b+" ? "+lt+" : ("+a+" > "+b+" ? "+gt+" : 0)";
+            }
+            return new Function("a,b", 'return ('+sorter+');');
+        }],
+
         [Array, 'shortest', function () {
 
             return slice(arguments).reduce(function (p, c) {

--- a/sinful.js
+++ b/sinful.js
@@ -473,6 +473,24 @@ void function (bless) {
 
         }],
 
+        // http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+        // Array unbiased shuffling
+        // using Fisher-Yates-Knuth shuffle algorithm
+        // https://github.com/foo123/sinful.js
+        [Array.prototype, 'shuffle', function () {
+            var N, perm, swap, arr = this;
+            N = arr.length;
+            while ( N-- )
+            { 
+                perm = Math.round(N*Math.random()); 
+                swap = arr[ N ]; 
+                arr[ N ] = arr[ perm ]; 
+                arr[ perm ] = swap; 
+            }
+            // in-place
+            return arr;
+        }],
+        
         [Array.prototype, 'unique', function (search) {
 
             search = search || this.indexOf;

--- a/test/Array.sorter.js
+++ b/test/Array.sorter.js
@@ -1,0 +1,15 @@
+suite('Array.sorter');
+require('../sinful');
+
+
+test('as showcased on the wiki', function(){
+    
+    var arr = [
+        {f1: 1, f2: {f3: 3} },
+        {f1: 1, f2: {f3: 4} },
+        {f1: -1, f2: {f3: 2} }
+    ];
+    var multiSorter = Array.sorter(['f1'],['f2.f3',-1]); // field f1 asc, field f2.f3 desc
+
+    require('assert').deepEqual(arr.sort(multiSorter), [{f1: -1, f2: {f3: 2} },{f1: 1, f2: {f3: 4} },{f1: 1, f2: {f3: 3}}]);
+});


### PR DESCRIPTION
Hello, added a new Array utility Array.sorter, (with associated test) that creates (and returns) a sorter
that can do multi-sub-sorting by multiple (and nested) keys each ascending or descending independantly
